### PR TITLE
Fix for new yapf

### DIFF
--- a/yapfify.el
+++ b/yapfify.el
@@ -55,19 +55,14 @@ If yapf exits with an error, the output will be shown in a help-window."
          (exit-code (yapfify-call-bin original-buffer tmpbuf)))
 
     ;; There are three exit-codes defined for YAPF:
-    ;; 0: Exit with success (change or no change)
+    ;; 0: Exit with success (change or no change on yapf >=0.11)
     ;; 1: Exit with error
     ;; 2: Exit with success and change (Backward compatibility)
     ;; anything else would be very unexpected.
-    (cond ((eq exit-code 0)
+    (cond ((or (eq exit-code 0) (eq exit-code 2))
            (with-current-buffer tmpbuf
              (copy-to-buffer original-buffer (point-min) (point-max)))
            (goto-char original-point))
-
-          ((eq exit-code 2)
-           (with-current-buffer tmpbuf
-            (copy-to-buffer original-buffer (point-min) (point-max)))
-          (goto-char original-point))
 
           ((eq exit-code 1)
            (with-help-window "*Yapf errors*"

--- a/yapfify.el
+++ b/yapfify.el
@@ -55,13 +55,10 @@ If yapf exits with an error, the output will be shown in a help-window."
          (exit-code (yapfify-call-bin original-buffer tmpbuf)))
 
     ;; There are three exit-codes defined for YAPF:
-    ;; 0: Exit with no change
+    ;; 0: Exit with success (change or no change)
     ;; 1: Exit with error
-    ;; 2: Exit with changes to files
     ;; anything else would be very unexpected.
-    (cond ((eq exit-code 0))
-
-          ((eq exit-code 2)
+    (cond ((eq exit-code 0)
              (with-current-buffer tmpbuf
                (copy-to-buffer original-buffer (point-min) (point-max)))
              (goto-char original-point))

--- a/yapfify.el
+++ b/yapfify.el
@@ -57,11 +57,17 @@ If yapf exits with an error, the output will be shown in a help-window."
     ;; There are three exit-codes defined for YAPF:
     ;; 0: Exit with success (change or no change)
     ;; 1: Exit with error
+    ;; 2: Exit with success and change (Backward compatibility)
     ;; anything else would be very unexpected.
     (cond ((eq exit-code 0)
-             (with-current-buffer tmpbuf
-               (copy-to-buffer original-buffer (point-min) (point-max)))
-             (goto-char original-point))
+           (with-current-buffer tmpbuf
+             (copy-to-buffer original-buffer (point-min) (point-max)))
+           (goto-char original-point))
+
+          ((eq exit-code 2)
+           (with-current-buffer tmpbuf
+            (copy-to-buffer original-buffer (point-min) (point-max)))
+          (goto-char original-point))
 
           ((eq exit-code 1)
            (with-help-window "*Yapf errors*"


### PR DESCRIPTION
Now `yapf` only returns 0/1 as exit codes
- 0 - Success (does not matter if file changed)
- 1 - Failure
