### PR TITLE
Fix #20: Package cl is deprecated.

### DIFF
--- a/yapfify.el
+++ b/yapfify.el
@@ -37,7 +37,7 @@
 ;;
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
 (defun yapfify-call-bin (input-buffer output-buffer start-line end-line)
   "Call process yapf on INPUT-BUFFER saving the output to OUTPUT-BUFFER.


### PR DESCRIPTION
In Emacs 27, `cl` is deprecated.
Require `cl-lib` instead of `cl`.