### PR TITLE
[fix #14] Use `get-buffer-create` instead of `generate-new-buffer`

### DIFF
--- a/yapfify.el
+++ b/yapfify.el
@@ -75,7 +75,7 @@ If yapf exits with an error, the output will be shown in a help-window."
                                                (= (char-before end) 13))
                                            (- end 1)
                                          end)))
-         (tmpbuf (generate-new-buffer "*yapfify*"))
+         (tmpbuf (get-buffer-create "*yapfify*"))
          (exit-code (yapfify-call-bin original-buffer tmpbuf start-line end-line)))
     (deactivate-mark)
     ;; There are three exit-codes defined for YAPF:


### PR DESCRIPTION
If it (`buffer-or-name`) is a string and a live buffer with that name already
exists, `get-buffer-create` returns that buffer.  If no such buffer exists, it
creates a new buffer.