### PR TITLE
[fix #14] Reuse *yapify* buffer

### DIFF
--- a/yapfify.el
+++ b/yapfify.el
@@ -75,7 +75,8 @@ If yapf exits with an error, the output will be shown in a help-window."
                                                (= (char-before end) 13))
                                            (- end 1)
                                          end)))
-         (tmpbuf (generate-new-buffer "*yapfify*"))
+         (tmpbuf (get-buffer-create "*yapfify*"))
+         (dummy (with-current-buffer tmpbuf (erase-buffer)))
          (exit-code (yapfify-call-bin original-buffer tmpbuf start-line end-line)))
     (deactivate-mark)
     ;; There are three exit-codes defined for YAPF:


### PR DESCRIPTION
This commit allows yapify to reuse the *yapify* buffer if it exists, or create a new one if not.