### PR TITLE
Do not modify the buffer if yapf provides no change.

### DIFF
--- a/yapfify.el
+++ b/yapfify.el
@@ -86,7 +86,10 @@ If yapf exits with an error, the output will be shown in a help-window."
     ;; anything else would be very unexpected.
     (cond ((or (eq exit-code 0) (eq exit-code 2))
            (with-current-buffer tmpbuf
-             (copy-to-buffer original-buffer (point-min) (point-max))))
+             (unless (eq (compare-buffer-substrings original-buffer nil nil
+                                                    nil nil nil)
+                         0)
+               (copy-to-buffer original-buffer (point-min) (point-max)))))
           ((eq exit-code 1)
            (error "Yapf failed, see %s buffer for details" (buffer-name tmpbuf))))
     ;; Clean up tmpbuf

--- a/yapfify.el
+++ b/yapfify.el
@@ -26,6 +26,8 @@
 ;; certain buffer, but more conveniently, a minor-mode 'yapf-mode' is provided
 ;; that turns on automatically running YAPF on a buffer before saving.
 ;;
+;; This file is modified by Yushun Cheng on 1 Sep 2023.
+;;
 ;; Installation:
 ;;
 ;; Add yapfify.el to your load-path.


### PR DESCRIPTION
Currently the buffer being formatted will always be modified when `yapfify-region` is run. This patch simply checks whether any changes are made before modifying the buffer, avoiding unnecessary edits.